### PR TITLE
Fixing build and adding support for '\nmid'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,10 @@ SOURCES_FULL = \
   $(BASE_SOURCES) \
   $(SRC_DIR)/commands/math.js \
   $(SRC_DIR)/commands/text.js \
-  $(SRC_DIR)/commands/math/*.js
+  $(SRC_DIR)/commands/math/basicSymbols.js \
+  $(SRC_DIR)/commands/math/advancedSymbols.js \
+  $(SRC_DIR)/commands/math/commands.js \
+  $(SRC_DIR)/commands/math/LatexCommandInput.js
 # FIXME text.js currently depends on math.js (#435), restore these when fixed:
 # $(SRC_DIR)/commands/*.js \
 # $(SRC_DIR)/commands/*/*.js

--- a/src/commands/math/advancedSymbols.js
+++ b/src/commands/math/advancedSymbols.js
@@ -141,6 +141,7 @@ LatexCmds.preceq = bind(VanillaSymbol, '\\preceq ', '&#8828;');
 LatexCmds.succeq = bind(VanillaSymbol, '\\succeq ', '&#8829;');
 LatexCmds.simeq = bind(VanillaSymbol, '\\simeq ', '&#8771;');
 LatexCmds.mid = bind(VanillaSymbol, '\\mid ', '&#8739;');
+LatexCmds.nmid = bind(VanillaSymbol, '\\nmid', '&#8740;');
 LatexCmds.ll = bind(VanillaSymbol, '\\ll ', '&#8810;');
 LatexCmds.gg = bind(VanillaSymbol, '\\gg ', '&#8811;');
 LatexCmds.parallel = bind(VanillaSymbol, '\\parallel ', '&#8741;');


### PR DESCRIPTION
This pull request fixes the bug outlined in #6 .

Also,

The pull request adds the support for the command '\nmid', which is required in some Math courses.